### PR TITLE
gas: add `Manager` with user-defined cache of price results

### DIFF
--- a/gas_price_manager.go
+++ b/gas_price_manager.go
@@ -1,0 +1,72 @@
+package gas
+
+import (
+	"math/big"
+	"sync"
+	"time"
+)
+
+type priceResult struct {
+	fetchedAt time.Time
+	price     *big.Int
+}
+
+// Manager is a gas price fetcher with a cache of recent results, and user-defined max age for those results.
+//
+// A Manager instance's cache is per priority level. It also has an default priority to simplify usage.
+type Manager struct {
+	defaultPriority GasPriority
+	lastPrices      map[GasPriority]priceResult
+	maxAge          time.Duration
+
+	mu sync.Mutex
+}
+
+// NewManager creates a new gas price manager, with the default priority set to "fast" (~1 min confirmation).
+func NewManager(maxResultAge time.Duration) *Manager {
+	return &Manager{
+		defaultPriority: GasPriorityFast,
+		lastPrices:      make(map[GasPriority]priceResult),
+		maxAge:          maxResultAge,
+	}
+}
+
+// NewManager creates a new gas price manager, with the default priority set to the user defined defaultPriority
+func NewManagerWithDefault(maxResultAge time.Duration, defaultPriority GasPriority) *Manager {
+	return &Manager{
+		defaultPriority: defaultPriority,
+		lastPrices:      make(map[GasPriority]priceResult),
+		maxAge:          maxResultAge,
+	}
+}
+
+// SuggestGasPrice either fetches a new gas price, or uses the stored result if the most recent cache is present and not too old.
+func (mgr *Manager) SuggestGasPrice(priority GasPriority) (*big.Int, error) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	// if we have a result saved for this priority level, and it's not to old, use it
+	if res, ok := mgr.lastPrices[priority]; ok {
+		if time.Since(res.fetchedAt) <= mgr.maxAge {
+			return res.price, nil
+		}
+	}
+
+	// if not, fetch the price for this priority level, store it, and return it
+	price, err := SuggestGasPrice(priority)
+	if err != nil {
+		return nil, err
+	}
+
+	mgr.lastPrices[priority] = priceResult{
+		fetchedAt: time.Now(),
+		price:     price,
+	}
+
+	return price, nil
+}
+
+// SuggestDefaultGasPrice behaves like SuggestGasPrice, instead using the default priority level defined upon Manager construction.
+func (mgr *Manager) SuggestDefaultGasPrice() (*big.Int, error) {
+	return mgr.SuggestGasPrice(mgr.defaultPriority)
+}

--- a/gas_price_manager_test.go
+++ b/gas_price_manager_test.go
@@ -1,0 +1,32 @@
+package gas
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGasPriceManager(t *testing.T) {
+	mgr := NewManager(100 * time.Millisecond)
+
+	// 1. should use a cached result up til duration has passed
+	// - we can ensure a cached result is used by manually setting a cached result as -1
+	mgr.lastPrices[GasPriorityFast] = priceResult{
+		fetchedAt: time.Now(),
+		price:     big.NewInt(-1),
+	}
+	price1, err := mgr.SuggestGasPrice(GasPriorityFast)
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(-1), price1)
+
+	// 2. should fetch a new result after duration has passed
+	time.Sleep(101 * time.Millisecond)
+	price2, err := mgr.SuggestGasPrice(GasPriorityFast)
+	require.NoError(t, err)
+	assert.NotEqual(t, big.NewInt(-1), price2)
+	assert.Equal(t, price2.Cmp(big.NewInt(0)), 1)
+}

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## Overview
- Adds `gas.Manager`
   - User-defined `maxAge` of results
   - Gas price results cached by priority level (e.g. "fast" is cached independently of "safeLow") 
   - Two methods to get price: `SuggestGasPrice(priority)` and `SuggestDefaultGasPrice()` which uses user-defined default priority
- Adds tests for `gas.Manager`

## Notes
Closes #2 
Thanks to @jalextowle for the idea! :)