### PR TITLE
gas: remove unnecessary internal usage of pointers

### DIFF
--- a/gas_price_test.go
+++ b/gas_price_test.go
@@ -44,7 +44,7 @@ func TestLoadGasPrices(t *testing.T) {
 
 func TestGasPriceManager(t *testing.T) {
 	// create "phony" negative price result so we know the cache is being used
-	prices := &ethGasStationResponse{
+	prices := ethGasStationResponse{
 		Fast:    -1.0,
 		Fastest: -1.0,
 		SafeLow: -1.0,


### PR DESCRIPTION
## Overview

This PR simply removes the unnecessary usage of the type `*ethGasStationResponse` when the pointer type is not needed.

Since this is a change only to internal and un-exported types/functions, this PR makes no breaking changes to the public API. 

Performance impacts will be negligible to nonexistent. 